### PR TITLE
Integrating frontend and backend to save and render experience settin…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import Project from "./components/profile/project/project";
 import Contact from "./components/profile/contact";
 import Profile from "./components/profile/profile";
 import ProjectSettings from "./components/admin/project/projectSettings";
-import ExperienceSettings from "./components/admin/experienceSettings";
+import ExperienceSettings from "./components/admin/experience/experienceSettings";
 import SkillSettings from "./components/admin/skillSettings";
 import ProfileSettings from "./components/admin/profileSettings";
 import "bootstrap/dist/css/bootstrap.min.css";

--- a/src/components/admin/experience/experienceSettings.jsx
+++ b/src/components/admin/experience/experienceSettings.jsx
@@ -1,0 +1,180 @@
+import { useState, useEffect } from "react";
+import { CSSTransition } from "react-transition-group";
+import { ProjectOutlined, PlusOutlined } from "@ant-design/icons";
+import Modal from "../../common/modal";
+import AddExperienceSection from "./helpers/addExperienceSection";
+import {
+  experienceViewModel,
+  validateExperience,
+  validateProperty,
+} from "../../../models/experience";
+import { getExperiences, postExperience } from "../../../services/experience";
+
+const ExperienceSettings = () => {
+  const [showModal, setShowModal] = useState(false);
+  const [experiences, setExperiences] = useState([]);
+  const [payload, setPayload] = useState(experienceViewModel);
+  const [errors, setErrors] = useState({});
+
+  const buttons = [
+    { id: "close", text: "Close", color: "primary" },
+    { id: "save", text: "Save", color: "primary" },
+  ];
+
+  const handleChange = (e) => {
+    e.stopPropagation();
+    const { name, value, checked } = e.target;
+
+    const { error } = validateProperty(name, value);
+    if (error) {
+      setErrors((prevState) => {
+        return { ...prevState, [name]: error.details[0].message };
+      });
+    } else {
+      errors[name] && delete errors[name];
+    }
+
+    switch (name) {
+      case "isCurrentlyWorking":
+        return setPayload((prevState) => {
+          return { ...prevState, [name]: checked };
+        });
+
+      default:
+        return setPayload((prevState) => {
+          return { ...prevState, [name]: value };
+        });
+    }
+  };
+
+  const handleClick = async (e) => {
+    e.preventDefault();
+    const { name } = e.target;
+
+    switch (name) {
+      case "close":
+        setErrors({});
+        setPayload(experienceViewModel);
+        return setShowModal(false);
+
+      case "save":
+        const { error } = validateExperience(payload);
+        let err = { ...errors };
+
+        if (error) {
+          error.details.map((detail) => (err[detail.path[0]] = detail.message));
+          return setErrors(err);
+        }
+
+        const res = await postExperience(payload);
+
+        setExperiences((prevState) => {
+          return [...prevState, res];
+        });
+        setErrors({});
+        setPayload(experienceViewModel);
+        return setShowModal(false);
+
+      default:
+        setErrors({});
+        setPayload(experienceViewModel);
+        return setShowModal(false);
+    }
+  };
+
+  useEffect(() => {
+    async function fetchData() {
+      const res = await getExperiences();
+      setExperiences(res);
+    }
+    fetchData();
+  }, []);
+
+  return (
+    <>
+      <div className="row mt-3">
+        <div className="row">
+          <div className="col-sm-4">
+            <div className="input-group">
+              <span className="input-group-text fs-3">
+                <PlusOutlined />
+              </span>
+              <button
+                className="btn btn-primary w-50"
+                onClick={() => setShowModal(true)}
+              >
+                Add Experience
+              </button>
+            </div>
+          </div>
+          <div className="col-sm-8">
+            <div className="alert alert-primary">
+              <ProjectOutlined style={{ fontSize: "2em" }} />
+              {experiences.length > 1
+                ? `Total ${experiences.length} organisations I explored`
+                : `Total ${experiences.length} organisation I explored`}
+            </div>
+          </div>
+        </div>
+        <div className="row mt-5">
+          <div className="col-12">
+            <table className="table table-striped">
+              <thead className="thead-dark">
+                <tr>
+                  <th>#</th>
+                  <th>Company Name</th>
+                  <th>Title</th>
+                  <th>Job Type</th>
+                  <th>Start Date</th>
+                  <th>End Date</th>
+                </tr>
+              </thead>
+              {experiences.length > 0 && (
+                <tbody>
+                  {experiences.map(
+                    (
+                      { _id, company, profile_headline, employement_type },
+                      index
+                    ) => (
+                      <tr key={_id}>
+                        <td>{index + 1}</td>
+                        <td>{company.name}</td>
+                        <td>{profile_headline}</td>
+                        <td>{employement_type}</td>
+                        <td>{company.start_date}</td>
+                        <td>{company.end_date}</td>
+                      </tr>
+                    )
+                  )}
+                </tbody>
+              )}
+            </table>
+          </div>
+        </div>
+      </div>
+      <CSSTransition
+        in={showModal}
+        timeout={500}
+        classNames="modal"
+        unmountOnExit
+        onEnter={() => (document.body.style.overflow = "hidden")}
+        onExited={() => (document.body.style.overflow = "auto")}
+      >
+        <Modal
+          onClick={(e) => handleClick(e)}
+          title={"Adding Experience"}
+          titleInformation={"Please provide the following information"}
+          buttons={buttons}
+        >
+          <AddExperienceSection
+            payload={payload}
+            errors={errors}
+            onChange={(e) => handleChange(e)}
+          />
+        </Modal>
+      </CSSTransition>
+    </>
+  );
+};
+
+export default ExperienceSettings;

--- a/src/components/admin/experience/helpers/addExperienceSection.jsx
+++ b/src/components/admin/experience/helpers/addExperienceSection.jsx
@@ -1,0 +1,108 @@
+import Checkbox from "../../../common/checkbox";
+import Input from "../../../common/input";
+import TextArea from "../../../common/textArea";
+import MonthYearSelectSection from "../../helpers/monthYearSelectSection";
+import Select from "../../../common/select";
+
+const AddExperienceSection = ({ payload, errors, onChange }) => {
+  const jobTypes = [
+    { value: "Job Type" },
+    { id: "Full-time", value: "Full-time" },
+    { id: "Part-time", value: "Part-time" },
+    { id: "Self-employed", value: "Self-employed" },
+    { id: "Freelance", value: "Freelance" },
+    { id: "Internship", value: "Internship" },
+    { id: "Trainee", value: "Trainee" },
+  ];
+  const pointerEventAndOpacity = payload["isCurrentlyWorking"]
+    ? "pe-none opacity-50"
+    : "";
+
+  return (
+    <>
+      <Input
+        label="Title"
+        name="title"
+        type="text"
+        value={payload["title"]}
+        error={errors["title"]}
+        onChange={onChange}
+      />
+      <Input
+        label="Profile Headline"
+        name="profileHeadline"
+        type="text"
+        value={payload["profileHeadline"]}
+        error={errors["profileHeadline"]}
+        onChange={onChange}
+      />
+      <TextArea
+        name="description"
+        label="Description"
+        rows="3"
+        value={payload["description"]}
+        error={errors["description"]}
+        onChange={onChange}
+      />
+      <Input
+        label={"Company Name"}
+        name="companyName"
+        type="text"
+        value={payload["companyName"]}
+        error={errors["companyName"]}
+        onChange={onChange}
+      />
+      <div className="form-group">
+        <label htmlFor="">Job Type</label>
+        <Select
+          options={jobTypes}
+          name="jobType"
+          value={payload["jobType"]}
+          error={errors["jobType"]}
+          onChange={onChange}
+        />
+      </div>
+      <Checkbox
+        label="I am currently working"
+        name="isCurrentlyWorking"
+        checked={payload["isCurrentlyWorking"]}
+        value={payload["isCurrentlyWorking"]}
+        onChange={onChange}
+      />
+      <MonthYearSelectSection
+        label="Start Date"
+        monthName="startMonth"
+        yearName="startYear"
+        monthValue={payload["startMonth"]}
+        yearValue={payload["startYear"]}
+        error={errors["startMonth"] || errors["startYear"]}
+        onChange={onChange}
+      />
+      <MonthYearSelectSection
+        label="End Date"
+        pointerEventAndOpacity={pointerEventAndOpacity}
+        error={
+          !payload["isCurrentlyWorking"] &&
+          (errors["endMonth"] || errors["endYear"])
+        }
+        monthName="endMonth"
+        yearName="endYear"
+        monthValue={
+          payload["isCurrentlyWorking"] ? "Month" : payload["endMonth"]
+        }
+        yearValue={payload["isCurrentlyWorking"] ? "Year" : payload["endYear"]}
+        onChange={onChange}
+      />
+      <Input
+        label="Company Location"
+        name="companyLocation"
+        type="text"
+        value={payload["companyLocation"]}
+        error={errors["companyLocation"]}
+        onChange={onChange}
+      />
+    </>
+  );
+};
+
+export default AddExperienceSection;

--- a/src/components/admin/project/helpers/multipageModal.jsx
+++ b/src/components/admin/project/helpers/multipageModal.jsx
@@ -15,13 +15,28 @@ const MultipageModal = ({
   errs["images"] && delete errs["images"];
   const disabled = Object.keys(errs).length > 0 ? "disabled" : "";
   if (page === 1) {
-    buttons.push({ id: "next", text: "Next", disabled: disabled });
+    buttons.push({
+      id: "next",
+      text: "Next",
+      color: "success",
+      disabled: disabled,
+    });
   } else if (page === pages.length) {
-    buttons.push({ id: "back", text: "Back" });
-    buttons.push({ id: "save", text: "Save", disabled: disabled });
+    buttons.push({ id: "back", text: "Back", color: "success" });
+    buttons.push({
+      id: "save",
+      text: "Save",
+      color: "success",
+      disabled: disabled,
+    });
   } else {
-    buttons.push({ id: "back", text: "Back" });
-    buttons.push({ id: "next", text: "Next", disabled: disabled });
+    buttons.push({ id: "back", text: "Back", color: "success" });
+    buttons.push({
+      id: "next",
+      text: "Next",
+      color: "success",
+      disabled: disabled,
+    });
   }
 
   const renderHeaderSection = () => {

--- a/src/components/common/checkbox.jsx
+++ b/src/components/common/checkbox.jsx
@@ -1,6 +1,6 @@
 const Checkbox = ({ label, ...rest }) => {
   return (
-    <div className="form-check mt-2 mb-3">
+    <div className="form-check mt-3 mb-3">
       <input className="form-check-input" type="checkbox" {...rest} />
       <label className="form-check-label">{label}</label>
     </div>

--- a/src/components/common/modal.jsx
+++ b/src/components/common/modal.jsx
@@ -1,4 +1,12 @@
-const Modal = ({ children, title, onClick, buttons, header, backdrop }) => {
+const Modal = ({
+  children,
+  title,
+  onClick,
+  buttons,
+  header,
+  titleInformation,
+  backdrop,
+}) => {
   const renderHeaderSection = () => {
     if (header) {
       return header;
@@ -7,6 +15,7 @@ const Modal = ({ children, title, onClick, buttons, header, backdrop }) => {
       <div className="modal-header">
         <div className="modal-title">
           <h5>{title}</h5>
+          <p>{titleInformation}</p>
         </div>
         <button
           type="button"
@@ -25,7 +34,7 @@ const Modal = ({ children, title, onClick, buttons, header, backdrop }) => {
           key={bt.id}
           type="button"
           name={bt.id}
-          className={`btn btn-success ${bt?.disabled}`}
+          className={`btn btn-${bt.color} ${bt?.disabled}`}
           onClick={onClick}
         >
           {bt.text}

--- a/src/components/common/select.jsx
+++ b/src/components/common/select.jsx
@@ -1,21 +1,37 @@
-const Select = ({ options, ...rest }) => {
+import { InfoCircleFilled } from "@ant-design/icons";
+
+const Select = ({ options, error, ...rest }) => {
   return (
-    <select className="form-select" {...rest}>
-      {options.map((option) => {
-        if (!option.id) {
+    <>
+      <select className="form-select" {...rest}>
+        {options.map((option) => {
+          if (!option.id) {
+            return (
+              <option key={option.value} value="">
+                {option.value}
+              </option>
+            );
+          }
           return (
-            <option key={option.value} value="">
+            <option key={option.id} value={option.id}>
               {option.value}
             </option>
           );
-        }
-        return (
-          <option key={option.id} value={option.id}>
-            {option.value}
-          </option>
-        );
-      })}
-    </select>
+        })}
+      </select>
+      {error && (
+        <p className="text-danger mt-2">
+          <InfoCircleFilled
+            style={{
+              fontSize: "1.3rem",
+              marginRight: "0.3rem",
+              verticalAlign: "middle",
+            }}
+          />
+          <span>{error}</span>
+        </p>
+      )}
+    </>
   );
 };
 

--- a/src/components/profile/project/helpers/projectImages.jsx
+++ b/src/components/profile/project/helpers/projectImages.jsx
@@ -5,7 +5,7 @@ import { Carousel } from "react-responsive-carousel";
 
 const ProjectImages = ({ projectId, setShowModal }) => {
   const [images, setImages] = useState([]);
-  const buttons = [{ id: "close", text: "Close" }];
+  const buttons = [{ id: "close", text: "Close", color: "success" }];
 
   useEffect(() => {
     async function fetchData() {

--- a/src/models/experience.js
+++ b/src/models/experience.js
@@ -1,0 +1,49 @@
+import Joi from "joi";
+
+export const experienceViewModel = {
+  title: "",
+  profileHeadline: "",
+  description: "",
+  companyName: "",
+  isCurrentlyWorking: false,
+  companyLocation: "",
+  jobType: "",
+  startMonth: "",
+  startYear: "",
+  endMonth: "",
+  endYear: "",
+};
+
+const experienceSchema = {
+  title: Joi.string().required().label("Title"),
+  profileHeadline: Joi.string().required().label("Profile Headline"),
+  description: Joi.string().required().label("Description"),
+  companyName: Joi.string().required().label("Company Name"),
+  companyLocation: Joi.string().required().label("Company Location"),
+  jobType: Joi.string().required().label("Job Type"),
+  startMonth: Joi.string().required().label("Start Date"),
+  startYear: Joi.string().required().label("Start Date"),
+  endMonth: Joi.string().required().label("End Date"),
+  endYear: Joi.string().required().label("End Date"),
+};
+
+export const validateProperty = (name, value) => {
+  if (name === "isCurrentlyWorking") return { error: null };
+  const field = { [name]: value };
+  const fieldSchema = Joi.object({ [name]: experienceSchema[name] });
+  return fieldSchema.validate(field);
+};
+
+export const validateExperience = (experience) => {
+  const expSchema = { ...experienceSchema };
+  const exp = { ...experience };
+  if (exp["isCurrentlyWorking"]) {
+    delete expSchema["endMonth"];
+    delete expSchema["endYear"];
+    delete exp["endMonth"];
+    delete exp["endYear"];
+  }
+  delete exp["isCurrentlyWorking"];
+  const schema = Joi.object(expSchema);
+  return schema.validate(exp, { abortEarly: false });
+};

--- a/src/services/company.js
+++ b/src/services/company.js
@@ -1,9 +1,0 @@
-import axios from "axios";
-
-const baseUrl = process.env.REACT_APP_INTERACTIVERESUME_BASEURL;
-
-export async function getProfile() {
-  const profile = await axios.get(`${baseUrl}/experiences`);
-
-  return profile.data;
-}

--- a/src/services/experience.js
+++ b/src/services/experience.js
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+const baseUrl = process.env.REACT_APP_INTERACTIVERESUME_BASEURL;
+
+export async function getExperiences() {
+  const experiences = await axios.get(`${baseUrl}/experiences`);
+
+  return experiences.data;
+}
+
+export async function postExperience(experience) {
+  const experiences = await axios.post(`${baseUrl}/experiences`, experience);
+
+  return experiences.data;
+}


### PR DESCRIPTION
### Description

- Creating add experience modal on experience setting page
- Implementing close and save functionality on experience setting modal page
- Render saved experience on experience setting page list.
- Implementing validations on each field on add experience modal on onChange and save event.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/55158793/177051562-d1e4f603-5f02-47e0-908a-ee6617cfde23.png">

### Testing

- Open Add experience modal and  check it render properly on experience setting page.
- Check validations on onChange of event of each field and on click of save button.

### Note For Reviewer

- Predecessor branch's are :
     - ExperienceSettings-Page-creating-experience-setting-page - [PR](https://github.com/Jay-Jha04/InteractiveResume-Frontend/pull/2)
    - Experience-Api-making-experience-document-responsible-storing-company-document - [PR](https://github.com/Jay-Jha04/InteractiveResume/pull/1)