### PR TITLE
Fixing Issue for  getting console errors and profile page not render properly

### DIFF
--- a/src/components/profile/profile.jsx
+++ b/src/components/profile/profile.jsx
@@ -10,9 +10,12 @@ const Profile = () => {
   useEffect(() => {
     async function fetchData() {
       const profile = await getProfile();
-      const profileImage = await getProfileImage(profile.profile_image);
       setProfile(profile);
-      setProfileImage(profileImage);
+
+      if (profile?.profile_image) {
+        const profileImage = await getProfileImage(profile.profile_image);
+        setProfileImage(profileImage);
+      }
     }
     fetchData();
   }, []);


### PR DESCRIPTION
### Description
- We get a console error on profile page when there is no profile pic as application trying to call profile pic Api with null id.
<img width="386" alt="image" src="https://user-images.githubusercontent.com/55158793/177952472-6249708d-f4c4-4817-ae12-f507e820efbd.png">

### Testing

- Whenever we goto profile page it render properly without any console errors when there is no profile pics.

### Note For Reviewer

- None